### PR TITLE
Fix a syntax error in announce-header.blade.php

### DIFF
--- a/resources/views/layouts/announce-header.blade.php
+++ b/resources/views/layouts/announce-header.blade.php
@@ -8,7 +8,7 @@
   @guest
       <a href="{{route('register')}}" class="mr-2">ユーザー登録（無料）</a>
       <a href="{{route('login')}}" class="">ログイン</a>
-  @endauth
+  @endguest
     </div>
   </div>
 </section>


### PR DESCRIPTION
# EN
## What

Replace `@endauth` with `@endguest`

## Why

- Though it doesn't show any syntax error when it boots an app, 2nd `@endguest` should be the end of `@guest` section.
- Therefore I opened this PR to propose modifying this line.

---
# 日本語
## What

`@endauth` を `@endguest` に置き換える

## Why

- アプリの起動時に構文エラーは表示されませんが、2番目の `@endguest` は `@guest` セクションの末尾である必要があるかと思います。
- そのため、この行の修正を提案するためにこの PR を Open しました。